### PR TITLE
fix(ci): trigger deploy workflow on master branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Workflow was configured for 'main' but default branch is 'master', so the Vite build and Pages deploy never ran. Also requires GitHub Pages source to be set to 'GitHub Actions' in repo settings.